### PR TITLE
Complete Exercise 1: Implement deterministic train/test split

### DIFF
--- a/ps3/data/__init__.py
+++ b/ps3/data/__init__.py
@@ -1,4 +1,4 @@
 from ._load_transform import load_transform
-from ._sample_split import create_sample_split
+from ._sample_split import create_sample_split, create_sample_column
 
-__all__ = ["create_sample_split", "load_transform"]
+__all__ = ["create_sample_split", "create_sample_column", "load_transform"]

--- a/ps3/data/_sample_split.py
+++ b/ps3/data/_sample_split.py
@@ -1,25 +1,84 @@
 import hashlib
+from typing import Iterable, Sequence, Union
 
 import numpy as np
+import pandas as pd
 
-# TODO: Write a function which creates a sample split based in some id_column and training_frac.
-# Optional: If the dtype of id_column is a string, we can use hashlib to get an integer representation.
-def create_sample_split(df, id_column, training_frac=0.8):
-    """Create sample split based on ID column.
+
+def _row_hash_to_fraction(values: Sequence) -> float:
+    """Convert a sequence of values for a row into a deterministic fraction in [0, 1).
+
+    We stringify each value, join with a separator, compute an MD5 hash and map the
+    integer hash into a floating point in [0,1).
+    """
+    # Use '|' as separator to avoid accidental collisions from concatenation
+    combined = "|".join(["" if v is None or (isinstance(v, float) and np.isnan(v)) else str(v) for v in values])
+    h = hashlib.md5(combined.encode("utf-8")).hexdigest()
+    as_int = int(h, 16)
+    # Map into [0,1) using 128-bit range of MD5
+    return as_int / float(2 ** 128)
+
+
+def create_sample_column(
+    df: pd.DataFrame,
+    columns: Union[str, Sequence[str]],
+    training_frac: float = 0.8,
+    sample_col: str = "sample",
+) -> pd.DataFrame:
+    """Create a reproducible sample column on a dataframe.
+
+    The function assigns each row to 'train' or 'test' based on a deterministic
+    hash of the provided column(s). If multiple columns are provided, the
+    combination of their values is used to compute the hash so duplicate
+    key-combinations receive the same assignment.
 
     Parameters
     ----------
     df : pd.DataFrame
-        Training data
-    id_column : str
-        Name of ID column
-    training_frac : float, optional
-        Fraction to use for training, by default 0.9
+        Input dataframe. Not modified in-place; a shallow copy is returned.
+    columns : str or sequence of str
+        Column name or list of column names to base the split on. These columns
+        must exist in `df`.
+    training_frac : float, default 0.8
+        Fraction of rows to assign to the training set. Must be between 0 and 1.
+    sample_col : str, default 'sample'
+        Name of the column to create containing values 'train' or 'test'.
 
     Returns
     -------
     pd.DataFrame
-        Training data with sample column containing train/test split based on IDs.
+        A copy of `df` with an added `sample_col` column.
     """
 
-    return df
+    if isinstance(columns, str):
+        cols = [columns]
+    elif isinstance(columns, Iterable):
+        cols = list(columns)
+    else:
+        raise TypeError("`columns` must be a column name or an iterable of column names")
+
+    if not 0 <= training_frac <= 1:
+        raise ValueError("`training_frac` must be between 0 and 1")
+
+    missing = [c for c in cols if c not in df.columns]
+    if missing:
+        raise KeyError(f"Columns not found in dataframe: {missing}")
+
+    out = df.copy()
+
+    # Compute deterministic fraction for each row
+    fractions = out[cols].apply(lambda row: _row_hash_to_fraction(row.values), axis=1)
+
+    out[sample_col] = np.where(fractions < float(training_frac), "train", "test")
+
+    return out
+
+
+# keep existing name for backward compatibility; implement using the new function
+def create_sample_split(df, id_column, training_frac=0.8):
+    """Backward-compatible wrapper around create_sample_column.
+
+    Parameters are the same as the old interface: id_column may be a single
+    column name (string).
+    """
+    return create_sample_column(df, id_column, training_frac=training_frac)

--- a/tests/test_sample_split.py
+++ b/tests/test_sample_split.py
@@ -1,0 +1,44 @@
+import pandas as pd
+
+
+def test_create_sample_column_single_column():
+    from ps3.data import create_sample_column
+
+    n = 100
+    df = pd.DataFrame({"id": list(range(1, n + 1))})
+    out = create_sample_column(df, "id", training_frac=0.8)
+
+    assert "sample" in out.columns
+    counts = out["sample"].value_counts()
+    # expect roughly 80/20 split; allow a small tolerance
+    assert counts.get("train", 0) >= 70
+    assert counts.get("test", 0) >= 10
+
+
+def test_create_sample_column_multiple_columns_grouping():
+    from ps3.data import create_sample_column
+
+    # Create duplicated keys across rows and ensure same assignment for duplicates
+    rows = []
+    for a in ["A", "B"]:
+        for b in [1, 2, 3]:
+            for dup in range(3):
+                rows.append({"col1": a, "col2": b, "val": dup})
+    df = pd.DataFrame(rows)
+    out = create_sample_column(df, ["col1", "col2"], training_frac=0.5)
+
+    # For each (col1,col2) combination, all rows should have the same sample
+    grouped = out.groupby(["col1", "col2"])
+    for _, g in grouped:
+        assert g["sample"].nunique() == 1
+
+
+def test_create_sample_column_reproducible():
+    from ps3.data import create_sample_column
+
+    df = pd.DataFrame({"id": ["x", "y", "z", "x"]})
+    out1 = create_sample_column(df, "id", training_frac=0.6)
+    out2 = create_sample_column(df, "id", training_frac=0.6)
+
+    # Assignments should be identical across runs
+    assert out1["sample"].tolist() == out2["sample"].tolist()


### PR DESCRIPTION
- Add create_sample_column() function using MD5 hash-based splitting
- Supports single or multiple columns for split key
- Ensures reproducible splits without relying on random seeds
- Maintains backward compatibility with create_sample_split()
- Add comprehensive unit tests for determinism and multi-column behavior
- All tests passing